### PR TITLE
Rimuove il riferimento alle statistiche

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -39,7 +39,6 @@ In questa categoria di dati rientrano gli indirizzi IP o i nomi a dominio dei co
 
 Tali dati, necessari per la fruizione dei servizi web, vengono anche trattati allo scopo di:
 
-- ottenere informazioni statistiche sull'uso dei servizi (pagine più visitate, numero di visitatori per fascia oraria o giornaliera, aree geografiche di provenienza, ecc.);
 - controllare il corretto funzionamento dei servizi offerti.
 
 I dati di navigazione non persistono per più di 3 MESI e vengono cancellati immediatamente dopo la loro aggregazione (salve eventuali necessità di accertamento di reati da parte dell'Autorità giudiziaria).


### PR DESCRIPTION
Meglio limitarsi a specificare solo i trattamenti effettivamente in uso.